### PR TITLE
[perf] Skip session baseline rebuild after the Initial snapshot freezes

### DIFF
--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -30,6 +30,8 @@ context            → read the final system prompt and active tools, then freez
 
 `event.systemPromptOptions` is available in `before_agent_start`, not `session_start`. Copy the structured options there, but do not freeze the prompt or tool set: later `before_agent_start` handlers may edit the prompt or call `pi.setActiveTools()`. Finalize in the first `context` event with `ctx.getSystemPrompt()` and pi's then-active tools.
 
+Once frozen, later `context` events skip the `buildSessionContext()` baseline rebuild and the `finalize()` call, which would only return the existing snapshot, while still filtering persisted synthetic identities from the event messages.
+
 Initial represents the first context observable by this extension runtime, whether from a real turn or the explicit silent probe. Never overwrite it. Conditional contributions inactive for that run are absent. Prompt and tool capture is load-order independent; message changes from later `context` handlers and provider-payload rewrites remain unobservable.
 
 Compare context-event messages with `buildSessionContext()` for the current session branch. Preserve custom messages and structurally unmatched non-custom messages so provider-context-only injections are not lost. Own every nested prompt, tool, message, source, and child value retained by the snapshot.

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,17 +91,22 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("context", (event, ctx) => {
 		const messages = probe.filterMessages(event.messages);
-		const baselineMessages = probe.filterMessages(
-			buildSessionContext(ctx.sessionManager.getEntries(), ctx.sessionManager.getLeafId()).messages,
-		);
-		capture.finalize({
-			systemPrompt: ctx.getSystemPrompt(),
-			messages,
-			baselineMessages,
-			allTools: pi.getAllTools(),
-			activeToolNames: pi.getActiveTools(),
-			origin: probe.isCurrentRun ? "synthetic-probe" : "real-turn",
-		});
+		// The Initial snapshot freezes on the first context event; a repeat
+		// finalize would discard its inputs, so skip the O(session) baseline
+		// rebuild and the no-op finalize once the snapshot exists.
+		if (capture.snapshot === undefined) {
+			const baselineMessages = probe.filterMessages(
+				buildSessionContext(ctx.sessionManager.getEntries(), ctx.sessionManager.getLeafId()).messages,
+			);
+			capture.finalize({
+				systemPrompt: ctx.getSystemPrompt(),
+				messages,
+				baselineMessages,
+				allTools: pi.getAllTools(),
+				activeToolNames: pi.getActiveTools(),
+				origin: probe.isCurrentRun ? "synthetic-probe" : "real-turn",
+			});
+		}
 		return messages === event.messages ? undefined : { messages };
 	});
 

--- a/test/index-context.test.ts
+++ b/test/index-context.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type {
+	BeforeAgentStartEvent,
+	ContextEvent,
+	ExtensionAPI,
+	ExtensionContext,
+	SessionEntry,
+	SessionStartEvent,
+} from "@earendil-works/pi-coding-agent";
+
+import { PROBE_IDENTITIES_CUSTOM_TYPE } from "../src/capture.ts";
+import registerExtension from "../src/index.ts";
+
+/** User message fixture for context events. */
+function userMessage(content: string, timestamp: number): ContextEvent["messages"][number] {
+	return { role: "user", content, timestamp } satisfies ContextEvent["messages"][number];
+}
+
+test("context handler skips the session baseline rebuild after the Initial snapshot freezes", () => {
+	const handlers = new Map<string, (...args: unknown[]) => unknown>();
+	const pi = {
+		on: (event: string, handler: (...args: unknown[]) => unknown) => {
+			handlers.set(event, handler);
+		},
+		// Not triggered by the events exercised below.
+		appendEntry: () => undefined,
+		registerCommand: () => undefined,
+		getAllTools: () => [],
+		getActiveTools: () => [],
+	} as unknown as ExtensionAPI;
+
+	// A resumed session with one real user message and the probe identities
+	// persisted by a prior runtime.
+	const probeUser = { role: "user", content: [], timestamp: 10 } satisfies ContextEvent["messages"][number];
+	const entries: SessionEntry[] = [
+		{
+			type: "message",
+			id: "1",
+			parentId: null,
+			timestamp: "2026-08-22T10:00:00Z",
+			message: userMessage("hello", 1),
+		},
+		{
+			type: "custom",
+			id: "2",
+			parentId: "1",
+			timestamp: "2026-08-22T10:01:00Z",
+			customType: PROBE_IDENTITIES_CUSTOM_TYPE,
+			data: { messages: [{ role: "user", timestamp: 10 }] },
+		},
+	];
+	let sessionReads = 0;
+	const ctx = {
+		getSystemPrompt: () => "system prompt",
+		sessionManager: {
+			getEntries: () => {
+				sessionReads += 1;
+				return entries;
+			},
+			getLeafId: () => "2",
+		},
+	} as unknown as ExtensionContext;
+
+	registerExtension(pi);
+	const start = handlers.get("session_start") as (event: SessionStartEvent, ctx: ExtensionContext) => unknown;
+	const agentStart = handlers.get("before_agent_start") as (event: BeforeAgentStartEvent, ctx: ExtensionContext) => unknown;
+	const context = handlers.get("context") as (
+		event: ContextEvent,
+		ctx: ExtensionContext,
+	) => { messages?: ContextEvent["messages"] } | undefined;
+
+	// Rehydrate the persisted probe identity, then prepare the first real run.
+	start({ type: "session_start", reason: "resume" }, ctx);
+	agentStart(
+		{ type: "before_agent_start", prompt: "hello", systemPrompt: "system prompt", systemPromptOptions: { cwd: "/tmp" } },
+		ctx,
+	);
+	assert.equal(sessionReads, 1);
+
+	const first = context({ type: "context", messages: [probeUser, userMessage("hello", 1)] }, ctx);
+	assert.equal(sessionReads, 2, "the first context event builds the session baseline");
+	assert.deepEqual(first, { messages: [userMessage("hello", 1)] });
+
+	const second = context({ type: "context", messages: [probeUser, userMessage("again", 2)] }, ctx);
+	assert.equal(sessionReads, 2, "a frozen snapshot must not rebuild the session baseline");
+	assert.deepEqual(second, { messages: [userMessage("again", 2)] });
+});


### PR DESCRIPTION
## Problem

The `pi.on("context")` handler runs on **every LLM request** and rebuilt the full session context baseline — `buildSessionContext()` over all session entries, plus the context-message projection — on each one. But `InitialCaptureState.finalize()` returns the **frozen** snapshot after the first capture and discards its inputs, so from the second request onward that O(session) rebuild was computed and thrown away. Pure per-request waste, quadratic across a long session.

## Fix

Guard the handler: when the capture snapshot is already frozen (`capture.snapshot !== undefined`), skip the `buildSessionContext()` baseline rebuild and the now-no-op `finalize()` call.

- **First-capture path is unchanged** — the `if` body is the original code verbatim.
- Probe-identity filtering of `event.messages` still runs on every request, so persisted synthetic probe messages keep being excluded from all later model contexts.
- One-line `doc/ARCHITECTURE.md` note per the repo doc contract (capture lifecycle change, behavior-neutral).
- Regression test `test/index-context.test.ts` drives the real handler through `session_start -> before_agent_start -> context x2` with a resumed-session fixture (persisted probe identities): asserts the session baseline is built exactly once and that the frozen path still filters probe messages. Verified the test fails against the unguarded handler (`sessionReads` 3 vs 2).

## Evidence

- `npm test` — 99/99 pass, exit 0
- `npm run check` (`tsc --noEmit && pnpm test`) — exit 0